### PR TITLE
made path split platform independent

### DIFF
--- a/xform/transforms/cmtk.py
+++ b/xform/transforms/cmtk.py
@@ -32,7 +32,7 @@ from .base import BaseTransform, TransformSequence
 __all__ = ['xform_cmtk']
 
 _search_path = os.environ['PATH']
-_search_path = [i for i in _search_path.split(';') if len(i) > 0]
+_search_path = [i for i in _search_path.split(os.pathsep) if len(i) > 0]
 _search_path += ['~/bin',
                  '/usr/lib/cmtk/bin/',
                  '/usr/local/lib/cmtk/bin',


### PR DESCRIPTION
Previously, the implementation for searching the $PATH variable split on the ';' character. This does not in unixlike systems, causing a failure to find the CMTK executable, or causing an exception:
    OSError: [Errno 63] File name too long
os.pathsep solves this problem